### PR TITLE
removed unavailable package from apt-get install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get install -y \
 	php7.0-cli \
 	php7.0-common \
 	php7.0-curl \
-	php7.0-dbg \
 	php7.0-dev \
 	php7.0-enchant \
 	php7.0-fpm \


### PR DESCRIPTION
Installing errored with `Unable to locate package php7.0-dbg`. Seems that the package is no longer available (https://github.com/oerdnj/deb.sury.org/issues/292).