### PR TITLE
Add php-zip extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get upgrade -y
 COPY debconf.selections /tmp/
 RUN debconf-set-selections /tmp/debconf.selections
 
+RUN apt-get install -y zip unzip
 RUN apt-get install -y \
 	php7.0 \
 	php7.0-bz2 \
@@ -42,7 +43,8 @@ RUN apt-get install -y \
 	php7.0-sybase \
 	php7.0-tidy \
 	php7.0-xmlrpc \
-	php7.0-xsl
+	php7.0-xsl \
+	php7.0-zip
 RUN apt-get install apache2 libapache2-mod-php7.0 -y
 RUN apt-get install mariadb-common mariadb-server mariadb-client -y
 RUN apt-get install postfix -y


### PR DESCRIPTION
Add php-zip extension for fix `composer install` error:

> [RuntimeException]
  The zip extension and unzip command are both missing, skipping.
  The php.ini used by your command-line PHP is: /etc/php/7.0/cli/php.ini