### PR TITLE
Fix incorrect path of fauria/lap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ fauria/lamp
 
 This Docker container implements a last generation LAMP stack with a set of popular PHP modules. Includes support for [Composer](https://getcomposer.org/), [Bower](http://bower.io/) and [npm](https://www.npmjs.com/) package managers and a Postfix service to allow sending emails through PHP [mail()](http://php.net/manual/en/function.mail.php) function.
 
-If you dont need support for MySQL/MariaDB, or your app runs on PHP 5.4, maybe [fauria/lap](https://hub.docker.com/r/fauria/lamp) suits your needs better.
+If you dont need support for MySQL/MariaDB, or your app runs on PHP 5.4, maybe [fauria/lap](https://hub.docker.com/r/fauria/lap) suits your needs better.
 
 Includes the following components:
 


### PR DESCRIPTION
It should go to https://hub.docker.com/r/fauria/lap/
not https://hub.docker.com/r/fauria/lamp/